### PR TITLE
Add tcp_keepalive=True and set read_timeout=3600 for video processing

### DIFF
--- a/src/rhubarb/video_processor/video_analyzer.py
+++ b/src/rhubarb/video_processor/video_analyzer.py
@@ -160,7 +160,7 @@ class VideoAnalysis(BaseModel):
         s3_config = Config(
             retries={"max_attempts": 0, "mode": "standard"}, signature_version="s3v4"
         )
-        br_config = Config(retries={"max_attempts": 0, "mode": "standard"})
+        br_config = Config(retries={"max_attempts": 0, "mode": "standard"}, tcp_keepalive=True, read_timeout=3600)
         session = values.get("boto3_session")
         cls._s3_client = session.client("s3", config=s3_config)
         cls._bedrock_client = session.client("bedrock-runtime", config=br_config)


### PR DESCRIPTION
*Description of changes:*

Add tcp_keepalive=True and read_timeout=3600 to prevent timeouts when using NOVA models with larger videos.

The timeout value of 3600s is recommended by: https://docs.aws.amazon.com/nova/latest/userguide/using-invoke-api.html

> The timeout period for inference calls to Amazon Nova is 60 minutes. By default, AWS SDK clients timeout after 1 minute. We recommend that you increase the read timeout period of your AWS SDK client to at least 60 minutes. For example, in the AWS Python botocore SDK, change the value of the read_timeoutfield in [botocore.config](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html#) to at least 3600.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
